### PR TITLE
Get rid of needless merge function

### DIFF
--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -226,7 +226,7 @@ function resolveFileDeep(helpers, parentCache, source, fullPath) {
     .then(function(newPaths) {
       // Contexts are the full path since multiple could be in the same folder
       // but different deps.
-      contexts[context] = merge(contexts[context] || {}, newPaths);
+      contexts[context] = Object.assign(contexts[context] || {}, newPaths);
       return when.map(Object.keys(newPaths), function(key) {
         var found = newPaths[key] && newPaths[key].path;
         if (found) {
@@ -273,14 +273,6 @@ function ensureFunctionsSource(sources, source) {
 }
 
 var slice = Array.prototype.slice.call.bind(Array.prototype.slice);
-
-function merge(a, b) {
-  var key;
-  for (key in b) {
-    a[key] = b[key];
-  }
-  return a;
-}
 
 function partial(fn) {
   var args = slice(arguments, 1);


### PR DESCRIPTION
Since Node.js 4 we have native `Object.assign` support for merge objects. So we can get rid of needless `merge` function in 3.x branch.