### PR TITLE
updating stylus and webpack to later versions, adding support for raw defines

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ plugins: [
 ],
 ```
 
+Passing in multidimensional objects
+
+```js
+plugins: [
+  new stylusLoader.OptionsPlugin({
+    default: {
+    rawDefine: { config: { go: 'deeper' } }
+
+    },
+  }),
+],
+```
+
 #### Using nib with stylus
 
 The easiest way of enabling `nib` is to import it in the stylus options:

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = function(source) {
   options.include = options.include || stylusOptions.include || [];
   options.set = options.set || stylusOptions.set || {};
   options.define = options.define || stylusOptions.define || {};
+  options.rawDefine = options.rawDefine || stylusOptions.rawDefine || {};
   options.paths = options.paths || stylusOptions.paths;
 
   if (options.sourceMap != null) {
@@ -75,6 +76,10 @@ module.exports = function(source) {
     } else if (key === 'define') {
       for (var defineName in value) {
         styl.define(defineName, value[defineName]);
+      }
+    } else if (key === 'rawDefine') {
+      for (var defineName in value) {
+        styl.define(defineName, value[defineName], true);
       }
     } else if (key === 'include') {
       needsArray(value).forEach(styl.include.bind(styl));

--- a/package.json
+++ b/package.json
@@ -25,20 +25,20 @@
   "dependencies": {
     "loader-utils": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",
-    "when": "~3.6.x"
+    "when": "~3.7.x"
   },
   "devDependencies": {
-    "benchmark": "^1.0.0",
-    "css-loader": "^0.14.0",
-    "mocha": "~2.1.0",
+    "benchmark": "^2.1.3",
+    "css-loader": "^0.27.3",
+    "mocha": "~3.2.0",
     "mocha-loader": "^1.0.0",
     "nib": "^1.0.4",
-    "node-libs-browser": "^0.5.2",
+    "node-libs-browser": "^2.0.0",
     "raw-loader": "~0.5.1",
-    "should": "~4.6.1",
-    "style-loader": "^0.12.2",
+    "should": "~11.2.1",
+    "style-loader": "^0.16.0",
     "stylus": ">=0.52.4",
-    "testem": "^0.8.3",
+    "testem": "^1.15.0",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.0.0"
   },


### PR DESCRIPTION
support for raw defines example:

```javascript
  plugins: [
    new ExtractText('css/main.css'),
    new webpack.LoaderOptionsPlugin({
      test: /\.styl$/,
      stylus: {
        default: {
          rawDefine: { config: { go: 'deeper' } }
        }
      }
    }),
  ],
```