### PR TITLE
Improved array iteration

### DIFF
--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -297,7 +297,7 @@ function partialRight(fn) {
 }
 
 function normalizePaths(paths) {
-  for(var i in paths) {
+  for(var i=0; i<paths.length; i++) {
     paths[i] = path.normalize(paths[i]);
   }
   return paths;


### PR DESCRIPTION
- Laravel-mix attaches [.tap function](https://github.com/JeffreyWay/laravel-mix/blob/master/src/helpers.js#L31) to all Arrays and for..in loop iterates over those functions making stylus-loader fail.

The error happens in `normalizePath` function as `for..in` gets the paths array from laravel-mix with `.tap` property attached so it tries to normalize a path of a function object resulting in the error below.

The suggested PR makes sure that the for loop only goes over array elements not helper functions too.

```
ERROR in ./resources/assets/stylus/app.styl
Module build failed: ModuleBuildError: Module build failed: TypeError: Path must be a string. Received [Function]
    at assertPath (path.js:28:11)
    at Object.normalize (path.js:1212:5)
    at normalizePaths (/mnt/projects/learning/laravel/gql-exp/node_modules/stylus-loader/lib/pathcache.js:303:21)
    at stylusFile (/mnt/projects/learning/laravel/gql-exp/node_modules/stylus-loader/lib/pathcache.js:102:14)
    at /mnt/projects/learning/laravel/gql-exp/node_modules/stylus-loader/lib/pathcache.js:159:32
    at tryCatchResolve (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/apply.js:46:23)
    at callAndResolve (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/apply.js:30:12)
    at callAndResolveNext (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/apply.js:40:4)
    at Fold.fulfilled (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:762:11)
    at tryCatchReject (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:840:30)
    at runContinuation1 (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:799:4)
    at Fulfilled.when (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:590:4)
    at Pending.run (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:481:13)
    at Scheduler._drain (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/Scheduler.js:62:19)
    at Scheduler.drain (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/Scheduler.js:27:9)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
    at runLoaders (/mnt/projects/learning/laravel/gql-exp/node_modules/webpack/lib/NormalModule.js:195:19)
    at /mnt/projects/learning/laravel/gql-exp/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /mnt/projects/learning/laravel/gql-exp/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/mnt/projects/learning/laravel/gql-exp/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at tryCatchReject (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:840:30)
    at runContinuation1 (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:799:4)
    at Rejected.when (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:623:4)
    at Pending.run (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/makePromise.js:481:13)
    at Scheduler._drain (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/Scheduler.js:62:19)
    at Scheduler.drain (/mnt/projects/learning/laravel/gql-exp/node_modules/when/lib/Scheduler.js:27:9)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
 @ ./resources/assets/stylus/app.styl
 @ multi ./resources/assets/js/main.js ./resources/assets/stylus/app.styl
```

