### PR TITLE
Fix evaluator for windows with special characters

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -151,6 +151,7 @@ CachedPathEvaluator.prototype.visitImport = function(imported) {
       found = utils.lookupIndex(name, this.paths, this.filename);
       index = true;
     }
+    if (!found) { found = [utils.lookup(this.filename, this.paths)]; index = false; }
   }
 
   // Throw if import failed


### PR DESCRIPTION
Fixes evaluator.js for Windows machines

Problem: install paths such as this

```
C:\[Course] Webpack 4\webpack-course
```

This install path is unsupported by glob (no escape character for [ or ] and the trick [[] and []] does not work)

Proposed solution is to use utils.lookup instead of utils.lookupIndex

Ideally glob could be patched to support [[] and []] however https://github.com/isaacs/node-glob requires all paths use / and not \ -- if glob doesn't work, no reason why we can't fallback to just looking for the file