### PR TITLE
Preventing cache collisions on identically-named Stylus imports

### DIFF
--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -21,15 +21,6 @@ function PathCache(contexts, sources, imports) {
   this.contexts = contexts;
   this.sources = sources;
   this.imports = imports;
-
-  // Non relative paths are simpler and looked up in this as a fallback
-  // to this.context.
-  this.simpleContext = {};
-  for (var dirname in this.contexts) {
-    for (var path in this.contexts[dirname]) {
-      this.simpleContext[path] = this.contexts[dirname][path];
-    }
-  }
 }
 
 // Return a promise for a PathCache.
@@ -47,8 +38,6 @@ PathCache.resolvers.reduce = reduceResolvers;
 PathCache.prototype.find = function(path, dirname) {
   if (this.contexts[dirname] && this.contexts[dirname][path]) {
     return this.contexts[dirname][path].path;
-  } else if (this.simpleContext[path]) {
-    return this.simpleContext[path].path;
   } else if (/.styl$/.test(path)) {
     // A user can specify @import 'something.styl' but if they specify
     // @import 'something' stylus adds .styl, we drop that here to see if we


### PR DESCRIPTION
## The bug

Imagine a directory structure like this:
```
dir1/
   └── index.styl (contains @import "./foo")
   └── foo.styl
dir2/
   └── index.styl (contains @import "./foo")
   └── foo.styl
```

Under existing behavior, the first time `@import "./foo"` is encountered, `./foo` will be cached and collide with any future files with the same name.

## What changed?

- Removed "simple" path caching so the import's containing directory is always considered
- Fixed regression on #44 

## Test plan

Manual testing + CI