### PR TITLE
Fix: disallow searching for nested imports in css files

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -277,6 +277,11 @@ async function getDependencies(
           return;
         }
 
+        // Avoid search nested imports in .css
+        if (path.extname(dependency) === ".css") {
+          return;
+        }
+
         loaderContext.addDependency(dependency);
 
         dependenciesOfDependencies.push(

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -588,6 +588,15 @@ exports[`loader resolve with webpack if stylus can't find it: errors 1`] = `Arra
 
 exports[`loader resolve with webpack if stylus can't find it: warnings 1`] = `Array []`;
 
+exports[`loader resolves broken css with webpack but does not import it: css 1`] = `
+"@import \\"css-keyframe.css\\";
+"
+`;
+
+exports[`loader resolves broken css with webpack but does not import it: errors 1`] = `Array []`;
+
+exports[`loader resolves broken css with webpack but does not import it: warnings 1`] = `Array []`;
+
 exports[`loader resolves css with webpack but does not import it: css 1`] = `
 "@import \\"css.css\\";
 "

--- a/test/fixtures/css-keyframe.css
+++ b/test/fixtures/css-keyframe.css
@@ -1,0 +1,4 @@
+.imported-css {
+  border: 5px;
+}
+@keyframes cdk-text-field-autofill-start{/*!*/}

--- a/test/fixtures/import-webpack-css-keyframe.styl
+++ b/test/fixtures/import-webpack-css-keyframe.styl
@@ -1,0 +1,1 @@
+@import "css-keyframe.css";

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -509,6 +509,19 @@ describe("loader", () => {
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });
 
+  it("resolves broken css with webpack but does not import it", async () => {
+    const testId = "./import-webpack-css-keyframe.styl";
+    const compiler = getCompiler(testId);
+    const stats = await compile(compiler);
+    const codeFromBundle = getCodeFromBundle(stats, compiler);
+    const codeFromStylus = await getCodeFromStylus(testId);
+
+    expect(codeFromBundle.css).toBe(codeFromStylus.css);
+    expect(codeFromBundle.css).toMatchSnapshot("css");
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
+
   it('should work "use" option', async () => {
     function plugin() {
       return (style) => {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixes #297 

### Breaking Changes

No

### Additional Info

No
