### PR TITLE
compress: false is ignored in production

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ function getStylusOptions(loaderContext, loaderOptions) {
       ? stylusOptions.resolveURL
       : { nocheck: true };
 
-  if (!stylusOptions.compress && isProductionLikeMode(loaderContext)) {
+  if (typeof stylusOptions.compress === 'undefined' && isProductionLikeMode(loaderContext)) {
     stylusOptions.compress = true;
   }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When setting `compress: false` in production mode, this setting is ignored.



### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
