### PR TITLE
fix(perf): avoud using `clona` for `stylus` options

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.12",
-    "klona": "^2.0.6",
     "normalize-path": "^3.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ export default async function stylusLoader(source) {
   const useSourceMap =
     typeof options.sourceMap === "boolean" ? options.sourceMap : this.sourceMap;
 
-  if (stylusOptions.sourcemap || useSourceMap) {
+  if (useSourceMap || stylusOptions.sourcemap) {
     styl.set(
       "sourcemap",
       useSourceMap

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -954,6 +954,22 @@ exports[`loader should work "use" option: errors 1`] = `[]`;
 
 exports[`loader should work "use" option: warnings 1`] = `[]`;
 
+exports[`loader should work and don't override loader options: css 1`] = `
+"body {
+  font: 12px Helvetica, Arial, sans-serif;
+}
+a.button {
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
+}
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhc2ljLnN0eWwiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBS0E7RUFDRSxNQUFtQixrQ0FBbkI7O0FBRUY7RUFQRSx1QkFBc0IsSUFBdEI7RUFDQSxvQkFBbUIsSUFBbkI7RUFDQSxlQUFjLElBQWQiLCJmaWxlIjoiYmFzaWMuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYm9yZGVyLXJhZGl1cygpXG4gIC13ZWJraXQtYm9yZGVyLXJhZGl1cyBhcmd1bWVudHNcbiAgLW1vei1ib3JkZXItcmFkaXVzIGFyZ3VtZW50c1xuICBib3JkZXItcmFkaXVzIGFyZ3VtZW50c1xuXG5ib2R5XG4gIGZvbnQgMTJweCBIZWx2ZXRpY2EsIEFyaWFsLCBzYW5zLXNlcmlmXG5cbmEuYnV0dG9uXG4gIGJvcmRlci1yYWRpdXMgNXB4Il19 */"
+`;
+
+exports[`loader should work and don't override loader options: errors 1`] = `[]`;
+
+exports[`loader should work and don't override loader options: warnings 1`] = `[]`;
+
 exports[`loader should work and respect the "compress" option with the "false" value: css 1`] = `
 "body {
   font: 12px Helvetica, Arial, sans-serif;

--- a/test/__snapshots__/sourceMap-options.test.js.snap
+++ b/test/__snapshots__/sourceMap-options.test.js.snap
@@ -289,3 +289,19 @@ a.button {
 exports[`"sourceMap" options should not generate source maps when value is "false": errors 1`] = `[]`;
 
 exports[`"sourceMap" options should not generate source maps when value is "false": warnings 1`] = `[]`;
+
+exports[`"sourceMap" options should work and allow to override source maps options: css 1`] = `
+"body {
+  font: 12px Helvetica, Arial, sans-serif;
+}
+a.button {
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
+}
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhc2ljLnN0eWwiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBS0E7RUFDRSxNQUFtQixrQ0FBbkI7O0FBRUY7RUFQRSx1QkFBc0IsSUFBdEI7RUFDQSxvQkFBbUIsSUFBbkI7RUFDQSxlQUFjLElBQWQiLCJmaWxlIjoiYmFzaWMuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYm9yZGVyLXJhZGl1cygpXG4gIC13ZWJraXQtYm9yZGVyLXJhZGl1cyBhcmd1bWVudHNcbiAgLW1vei1ib3JkZXItcmFkaXVzIGFyZ3VtZW50c1xuICBib3JkZXItcmFkaXVzIGFyZ3VtZW50c1xuXG5ib2R5XG4gIGZvbnQgMTJweCBIZWx2ZXRpY2EsIEFyaWFsLCBzYW5zLXNlcmlmXG5cbmEuYnV0dG9uXG4gIGJvcmRlci1yYWRpdXMgNXB4Il19 */"
+`;
+
+exports[`"sourceMap" options should work and allow to override source maps options: errors 1`] = `[]`;
+
+exports[`"sourceMap" options should work and allow to override source maps options: warnings 1`] = `[]`;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -249,7 +249,7 @@ describe("loader", () => {
     const testId = "./shallow-deep-literal.styl";
     const compiler = getCompiler(testId, {
       stylusOptions: {
-        dest: "deep/deep-literal.css",
+        dest: path.resolve(__dirname, "fixtures/"),
       },
     });
     const stats = await compile(compiler);
@@ -257,7 +257,7 @@ describe("loader", () => {
     const codeFromStylus = await getCodeFromStylus(testId, {
       stylusOptions: {
         resolveURL: { nocheck: true },
-        dest: "deep/deep-literal.css",
+        dest: path.resolve(__dirname, "fixtures/"),
       },
     });
 
@@ -1789,6 +1789,43 @@ describe("loader", () => {
     const compiler = getCompiler(testId);
     const stats = await compile(compiler);
 
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
+
+  it("should work and don't override loader options", async () => {
+    const testId = "./basic.styl";
+    const stylusOptions = {
+      compress: false,
+      resolveURL: {
+        nocheck: false,
+      },
+      sourcemap: {
+        comment: true,
+        inline: true,
+      },
+    };
+    const compiler = getCompiler(
+      testId,
+      { stylusOptions },
+      { mode: "production" }
+    );
+    const stats = await compile(compiler);
+    const codeFromBundle = getCodeFromBundle(stats, compiler);
+    const codeFromStylus = await getCodeFromStylus(testId, { stylusOptions });
+
+    expect(stylusOptions).toEqual({
+      compress: false,
+      resolveURL: {
+        nocheck: false,
+      },
+      sourcemap: {
+        comment: true,
+        inline: true,
+      },
+    });
+    expect(codeFromBundle.css).toBe(codeFromStylus.css);
+    expect(codeFromBundle.css).toMatchSnapshot("css");
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });

--- a/test/sourceMap-options.test.js
+++ b/test/sourceMap-options.test.js
@@ -249,4 +249,23 @@ describe('"sourceMap" options', () => {
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });
+
+  it("should work and allow to override source maps options", async () => {
+    const testId = "./basic.styl";
+    const stylusOptions = {
+      sourcemap: {
+        comment: true,
+        inline: true,
+      },
+    };
+    const compiler = getCompiler(testId, { stylusOptions });
+    const stats = await compile(compiler);
+    const codeFromBundle = getCodeFromBundle(stats, compiler);
+    const codeFromStylus = await getCodeFromStylus(testId, { stylusOptions });
+
+    expect(codeFromBundle.css).toBe(codeFromStylus.css);
+    expect(codeFromBundle.css).toMatchSnapshot("css");
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Better perf and less deps

### Breaking Changes

No

### Additional Info

Added test which allow to override source map options, I think we need to implement this for other CSS like loaders, but it will be separately